### PR TITLE
chore: add debian-fix-broken target to Makefile for system maintenance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,3 +118,15 @@ docker-full-pipeline:
 	@make docker-run-test IMAGE_TAG=$(IMAGE_TAG)
 	@make docker-buildx-push DOCKERFILE=$(DOCKERFILE) IMAGE_TAG=$(IMAGE_TAG)
 	@echo "✅ Full Docker pipeline completed successfully"
+
+.PHONY: debian-fix-broken
+debian-fix-broken:
+	sudo apt clean
+	sudo apt update
+	sudo apt upgrade
+	sudo apt --fix-broken install
+	sudo dpkg --configure -a
+	sudo apt --fix-broken install
+	sudo apt clean
+	sudo apt --fix-broken install
+	sudo dpkg --configure -a


### PR DESCRIPTION
- Introduced a new Makefile target `debian-fix-broken` to automate common system maintenance tasks, including cleaning, updating, upgrading, and fixing broken installations on Debian-based systems.
- This addition aims to simplify the process of maintaining a clean and functional development environment, enhancing usability for developers working with Debian systems.