### PR TITLE
chore: add installation scripts and documentation for zsh-dotfiles-prep

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,6 +1,13 @@
 {
   "permissions": {
-    "allow": ["Bash(chmod:*)"],
+    "allow": [
+      "Bash(chmod:*)",
+      "Bash(shellcheck:*)",
+      "Bash(sh:*)",
+      "Bash(grep:*)",
+      "Bash(docker build:*)",
+      "Bash(docker run:*)"
+    ],
     "deny": []
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,6 @@
+{
+  "permissions": {
+    "allow": ["Bash(chmod:*)"],
+    "deny": []
+  }
+}

--- a/.cursor/rules/homebrew_tap.mdc
+++ b/.cursor/rules/homebrew_tap.mdc
@@ -1,6 +1,6 @@
 ---
-description: 
-globs: 
+description:
+globs:
 alwaysApply: false
 ---
 # Homebrew Tap Formula Creation Guide

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,15 +2,15 @@
 ---
 version: 2
 updates:
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: weekly
-  allow:
-  - dependency-type: all
-  ignore:
-  - dependency-name: actions/stale
-  groups:
-    artifacts:
-      patterns:
-      - actions/*-artifact
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    allow:
+      - dependency-type: all
+    ignore:
+      - dependency-name: actions/stale
+    groups:
+      artifacts:
+        patterns:
+          - actions/*-artifact

--- a/.github/workflows/tmate.yml
+++ b/.github/workflows/tmate.yml
@@ -1,7 +1,7 @@
 ---
 # SOURCE: https://github.com/simonw/datasette/blob/main/.github/workflows/tmate.yml
 name: tmate session
-on:  # yamllint disable-line rule:truthy
+on: # yamllint disable-line rule:truthy
   # To enable a workflow to be triggered manually, you need to configure the workflow_dispatch event. You can manually trigger a workflow run using the GitHub API, GitHub CLI, or GitHub browser interface. For more information, see "Manually running a workflow."
   # SOURCE: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
   # https://github.com/mxschmitt/action-tmate#manually-triggered-debug

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,128 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Purpose
+
+This is a prerequisite installation tool that prepares machines to run the [bossjones/zsh-dotfiles](https://github.com/bossjones/zsh-dotfiles) chezmoi configuration. It bootstraps development environments with essential tools before applying dotfiles.
+
+## Quick Start
+
+```bash
+# Clone and run the complete setup
+git clone https://github.com/bossjones/zsh-dotfiles-prep.git
+cd zsh-dotfiles-prep
+./install.sh
+```
+
+## Essential Commands
+
+### Development and Testing
+```bash
+# Run code formatting and linting
+make style
+
+# Fix formatting issues automatically
+make style-fix
+
+# Set up development environment with Python venv and pre-commit hooks
+make install-hooks
+
+# Build and test Docker images for both architectures
+make docker-buildx
+
+# Run full test pipeline with Docker containers
+make docker-full-pipeline
+
+# Test individual platforms
+make docker-run-test PLATFORM=debian-12
+make docker-run-test PLATFORM=ubuntu-2204
+
+# Lint GitHub Actions workflows
+make lint-gh-actions
+
+# System maintenance for Debian/Ubuntu (fixes broken packages)
+make debian-fix-broken
+```
+
+### Docker Development and Debugging
+```bash
+# Login to GitHub Container Registry (requires CR_PAT env var)
+make ghcr-login
+
+# Build and push multi-platform images
+make docker-buildx-push DOCKERFILE=Dockerfile-debian-12 IMAGE_TAG=debian-12
+
+# Debug container with pre-configured environment
+make docker-run-test-debug IMAGE_TAG=debian-12
+
+# Interactive bash session in container
+make docker-run-test-bash IMAGE_TAG=debian-12
+```
+
+### Manual Testing
+```bash
+# Install all dependencies and run platform installer (recommended)
+./install.sh
+
+# Test the installer scripts directly
+./bin/zsh-dotfiles-prereq-installer --debug
+./bin/zsh-dotfiles-prereq-installer-linux --debug
+
+# Test in Docker containers
+docker run --rm -it debian:12 bash
+# Then curl and run the installer
+```
+
+## Architecture Overview
+
+### Core Installation Scripts (`/bin/`)
+- `install.sh` - POSIX-compliant meta-installer that detects platform, installs dependencies, and runs appropriate platform installer
+- `zsh-dotfiles-prereq-installer` - macOS installer with Homebrew, Xcode tools, TouchID sudo
+- `zsh-dotfiles-prereq-installer-linux` - Cross-platform installer for Debian/Ubuntu
+
+The platform installers are idempotent and install development toolchain (Rust, Python via pyenv, Node via fnm, asdf, chezmoi) plus create compatibility files (`~/compat.bash`, `~/compat.sh`) for environment setup.
+
+### Multi-Platform Testing
+Docker-based testing infrastructure with `Dockerfile-debian-12` and `Dockerfile-ubuntu-2204` supporting linux/amd64 and linux/arm64 architectures. Images published to GitHub Container Registry.
+
+### Tool Management
+- `Brewfile` contains 500+ development tools including languages, utilities, fonts, and VSCode extensions
+- Scripts handle version managers (pyenv, fnm, asdf) and PATH configuration
+- Security-conscious with sudo pattern validation and TouchID integration
+
+### Quality Assurance
+- `contrib/style.sh` - shellcheck and shfmt for shell script linting
+- `zizmor.yml` - GitHub Actions security auditing configuration
+- Automated testing across OS/architecture combinations in CI/CD
+
+## Development Workflow
+
+1. Make changes to installer scripts in `/bin/`
+2. Run `make style` to check formatting and linting
+3. Test locally with `--debug` flag
+4. Run `make docker-buildx` to test across platforms
+5. Use `make docker-full-pipeline` for comprehensive testing before commits
+
+## Environment Variables
+
+### Required for Docker Registry
+- `CR_PAT` - GitHub Personal Access Token for container registry authentication
+
+### Optional Configuration
+- `REGISTRY` (default: `ghcr.io`) - Container registry URL
+- `REGISTRY_OWNER` (default: `bossjones`) - Registry namespace
+- `DOCKERFILE` (default: `Dockerfile-debian-12`) - Which Dockerfile to use
+- `IMAGE_TAG` (default: `debian-12`) - Docker image tag
+- `PLATFORM` (default: `linux/amd64`) - Target platform for builds
+
+### Test Environment Variables
+- `ZSH_DOTFILES_PREP_GIT_NAME` - Git user name for testing
+- `ZSH_DOTFILES_PREP_GIT_EMAIL` - Git email for testing
+- `ZSH_DOTFILES_PREP_GITHUB_USER` - GitHub username for testing
+
+## Testing Notes
+
+The installer creates compatibility files that must work across different shell environments. Test with both bash and zsh. The `--debug` flag provides verbose output for troubleshooting installation issues.
+
+Use `make install-hooks` to set up the Python development environment with uv and pre-commit hooks before making changes.

--- a/Dockerfile-centos-9
+++ b/Dockerfile-centos-9
@@ -1,0 +1,95 @@
+FROM quay.io/centos/centos:stream9
+
+# Install base prerequisites and EPEL
+RUN dnf update -y && dnf install -y --allowerasing \
+    sudo \
+    curl \
+    wget \
+    git \
+    ca-certificates \
+    gnupg \
+    epel-release \
+    procps-ng \
+    glibc-locale-source \
+    glibc-langpack-en \
+    bash-completion \
+    && dnf clean all
+
+# Install development tools and libraries (after EPEL is available)
+RUN dnf install -y \
+    gcc \
+    gcc-c++ \
+    make \
+    pkgconfig \
+    llvm \
+    gzip \
+    bzip2-devel \
+    cairo-devel \
+    libffi-devel \
+    xz-devel \
+    ncurses-devel \
+    libpq-devel \
+    readline-devel \
+    sqlite-devel \
+    openssl-devel \
+    python3-devel \
+    sqlite \
+    tk-devel \
+    tree \
+    unzip \
+    vim \
+    xz \
+    zlib-devel \
+    openssl \
+    man-pages \
+    && dnf groupinstall -y "Development Tools" \
+    && dnf clean all
+
+# Configure locales
+RUN localedef -c -i en_US -f UTF-8 en_US.UTF-8
+
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+# The user ID and group ID for the testuser (matches github actions user)
+ENV USER_UID=1001
+ENV USER_GID=121
+
+
+RUN groupadd -g $USER_GID testuser && \
+    useradd -m -s /bin/bash -u $USER_UID  -g testuser testuser && \
+    usermod -aG wheel testuser && \
+    echo "testuser ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/testuser && \
+    echo "%testuser ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/testuser && \
+    chmod 0440 /etc/sudoers.d/testuser && \
+    mkdir -p /home/testuser/work && \
+    chown -R testuser:testuser /home/testuser && \
+    chmod -R 755 /home/testuser && \
+    echo "testuser:password" | chpasswd
+
+# Set up working directory for our tests
+WORKDIR /home/testuser/work
+
+# Copy repository files
+COPY --chown=testuser:testuser . .
+
+# Make sure scripts are executable
+RUN chmod +x bin/zsh-dotfiles-prereq-installer-linux && \
+    chown -R testuser:testuser /home/testuser/work && \
+    chmod -R 755 /home/testuser/work
+
+# Switch to non-root user (since script refuses to run as root)
+USER testuser
+
+# Set environment variables for the script
+ENV ZSH_DOTFILES_PREP_CI=1
+ENV ZSH_DOTFILES_PREP_GITHUB_USER=bossjones
+ENV ZSH_DOTFILES_PREP_SKIP_BREW_BUNDLE=1
+ENV HOME=/home/testuser
+ENV TMPDIR=/home/testuser/tmp
+
+# Create temp directory with proper permissions
+RUN mkdir -p $TMPDIR && chmod 755 $TMPDIR
+
+# The default command - will be overridden in CI but useful for local testing
+CMD ["bin/zsh-dotfiles-prereq-installer-linux"]

--- a/Makefile
+++ b/Makefile
@@ -130,3 +130,7 @@ debian-fix-broken:
 	sudo apt clean
 	sudo apt --fix-broken install
 	sudo dpkg --configure -a
+
+.PHONY: fix
+fix:
+	uv run pre-commit run -a --show-diff-on-failure

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,87 @@
+# Quickstart Guide
+
+This guide shows you how to quickly set up your development environment using zsh-dotfiles-prep.
+
+## Remote Installation (Recommended)
+
+Execute the installer directly from GitHub without cloning:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/bossjones/zsh-dotfiles-prep/main/install.sh | bash
+```
+
+This method:
+- Downloads and runs the installer automatically
+- Detects your platform (macOS, Debian, Ubuntu)
+- Installs all prerequisites for zsh-dotfiles
+- Creates compatibility files for your shell environment
+
+## Local Installation
+
+### 1. Clone the Repository
+
+```bash
+git clone https://github.com/bossjones/zsh-dotfiles-prep.git
+cd zsh-dotfiles-prep
+```
+
+### 2. Run the Installer
+
+```bash
+./install.sh
+```
+
+## What Gets Installed
+
+The installer will set up:
+
+- **Development Tools**: Git, curl, essential build tools
+- **Language Runtimes**: Python (via pyenv), Node.js (via fnm), Rust
+- **Version Managers**: asdf for managing multiple tool versions
+- **Shell Enhancement**: Zsh with compatibility configuration
+- **Dotfiles Manager**: chezmoi for configuration management
+- **Platform-Specific Tools**:
+  - macOS: Homebrew, Xcode Command Line Tools, TouchID sudo
+  - Linux: Package manager updates, development packages
+
+## Debug Mode
+
+For troubleshooting, run with debug output:
+
+```bash
+# Remote with debug
+curl -fsSL https://raw.githubusercontent.com/bossjones/zsh-dotfiles-prep/main/install.sh | bash -s -- --debug
+
+# Local with debug
+./install.sh --debug
+```
+
+## Next Steps
+
+After installation completes:
+
+1. **Restart your shell** or source the new configuration:
+   ```bash
+   source ~/.bashrc  # or ~/.zshrc
+   ```
+
+2. **Install your dotfiles** using chezmoi:
+   ```bash
+   chezmoi init --apply https://github.com/yourusername/dotfiles.git
+   ```
+
+3. **Verify installation** by checking tool availability:
+   ```bash
+   python --version
+   node --version
+   cargo --version
+   ```
+
+## Troubleshooting
+
+- **Permission Issues**: The installer may prompt for sudo access to install system packages
+- **Network Issues**: Ensure you have internet connectivity for downloading packages
+- **Platform Detection**: The installer automatically detects your OS; manual selection isn't needed
+- **Homebrew on macOS**: Installation may take 10-15 minutes for initial Homebrew setup
+
+For detailed troubleshooting, see the main [README.md](../README.md) or run with `--debug` flag.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,314 @@
+#!/bin/sh
+# install.sh - POSIX-compliant installer for zsh-dotfiles-prep dependencies
+# Works on both macOS and Linux (Debian/Ubuntu)
+
+set -e
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Logging functions
+log_info() {
+    printf "${GREEN}[INFO]${NC} %s\n" "$1"
+}
+
+log_warn() {
+    printf "${YELLOW}[WARN]${NC} %s\n" "$1"
+}
+
+log_error() {
+    printf "${RED}[ERROR]${NC} %s\n" "$1"
+}
+
+log_debug() {
+    if [ "${ZSH_DOTFILES_PREP_DEBUG:-0}" = "1" ]; then
+        printf "${BLUE}[DEBUG]${NC} %s\n" "$1"
+    fi
+}
+
+# Platform detection
+detect_platform() {
+    case "$(uname -s)" in
+        Darwin*)
+            PLATFORM="macos"
+            ;;
+        Linux*)
+            PLATFORM="linux"
+            # Detect specific Linux distribution
+            if [ -f /etc/os-release ]; then
+                . /etc/os-release
+                case "$ID" in
+                    debian|ubuntu)
+                        LINUX_DISTRO="$ID"
+                        ;;
+                    *)
+                        log_error "Unsupported Linux distribution: $ID"
+                        log_error "This script only supports Debian and Ubuntu"
+                        exit 1
+                        ;;
+                esac
+            else
+                log_error "Cannot detect Linux distribution"
+                exit 1
+            fi
+            ;;
+        *)
+            log_error "Unsupported platform: $(uname -s)"
+            log_error "This script only supports macOS and Linux"
+            exit 1
+            ;;
+    esac
+    log_info "Detected platform: $PLATFORM"
+    if [ "$PLATFORM" = "linux" ]; then
+        log_info "Linux distribution: $LINUX_DISTRO"
+    fi
+}
+
+# Set default environment variables (from GitHub Actions workflows)
+set_default_env_vars() {
+    log_info "Setting default environment variables"
+
+    # Core environment variables
+    export DEBIAN_FRONTEND="${DEBIAN_FRONTEND:-noninteractive}"
+    export ZSH_DOTFILES_PREP_CI="${ZSH_DOTFILES_PREP_CI:-1}"
+    export ZSH_DOTFILES_PREP_DEBUG="${ZSH_DOTFILES_PREP_DEBUG:-1}"
+    export ZSH_DOTFILES_PREP_GITHUB_USER="${ZSH_DOTFILES_PREP_GITHUB_USER:-bossjones}"
+    export ZSH_DOTFILES_PREP_SKIP_BREW_BUNDLE="${ZSH_DOTFILES_PREP_SKIP_BREW_BUNDLE:-0}"
+    export ZSH_DOTFILES_PREP_SKIP_SOFTWARE_UPDATES="${ZSH_DOTFILES_PREP_SKIP_SOFTWARE_UPDATES:-0}"
+
+    # Homebrew environment variables
+    export HOMEBREW_DEVELOPER="${HOMEBREW_DEVELOPER:-1}"
+    export HOMEBREW_NO_AUTO_UPDATE="${HOMEBREW_NO_AUTO_UPDATE:-1}"
+    export HOMEBREW_NO_ENV_HINTS="${HOMEBREW_NO_ENV_HINTS:-1}"
+
+    # Locale settings
+    export LANG="${LANG:-en_US.UTF-8}"
+    export LANGUAGE="${LANGUAGE:-en_US:en}"
+    export LC_ALL="${LC_ALL:-en_US.UTF-8}"
+
+    log_debug "Environment variables set"
+}
+
+# Check if running as root
+check_root() {
+    if [ "$(id -u)" = "0" ]; then
+        log_error "This script should not be run as root"
+        log_error "Please run as a regular user with sudo privileges"
+        exit 1
+    fi
+}
+
+# Check prerequisites
+check_prerequisites() {
+    log_info "Checking prerequisites"
+
+    # Check for sudo access
+    if ! sudo -n true 2>/dev/null; then
+        log_info "Testing sudo access (you may be prompted for password)"
+        if ! sudo true; then
+            log_error "This script requires sudo access"
+            exit 1
+        fi
+    fi
+
+    # Check for curl
+    if ! command -v curl >/dev/null 2>&1; then
+        log_error "curl is required but not installed"
+        exit 1
+    fi
+
+    # Check for git
+    if ! command -v git >/dev/null 2>&1; then
+        log_error "git is required but not installed"
+        exit 1
+    fi
+}
+
+# Install macOS dependencies
+install_macos_deps() {
+    log_info "Installing macOS dependencies"
+
+    # Install Xcode Command Line Tools if not present
+    if ! xcode-select -p >/dev/null 2>&1; then
+        log_info "Installing Xcode Command Line Tools"
+        xcode-select --install
+        log_info "Please complete the Xcode Command Line Tools installation and run this script again"
+        exit 0
+    fi
+
+    # Install Homebrew if not present
+    if ! command -v brew >/dev/null 2>&1; then
+        log_info "Installing Homebrew"
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+        # Add Homebrew to PATH for current session
+        if [ -f "/opt/homebrew/bin/brew" ]; then
+            eval "$(/opt/homebrew/bin/brew shellenv)"
+        elif [ -f "/usr/local/bin/brew" ]; then
+            eval "$(/usr/local/bin/brew shellenv)"
+        fi
+    fi
+
+    # Update Homebrew
+    log_info "Updating Homebrew"
+    brew update
+
+    # Install essential packages
+    log_info "Installing essential packages via Homebrew"
+    packages="python@3.12 go@1.20 zsh fish elvish shellcheck shfmt"
+
+    for package in $packages; do
+        if ! brew list "$package" >/dev/null 2>&1; then
+            log_info "Installing $package"
+            brew install "$package"
+        else
+            log_debug "$package already installed"
+        fi
+    done
+
+    # Install actionlint and zizmor for CI/CD tools
+    if ! command -v actionlint >/dev/null 2>&1; then
+        log_info "Installing actionlint"
+        brew install actionlint
+    fi
+
+    if ! command -v zizmor >/dev/null 2>&1; then
+        log_info "Installing zizmor"
+        brew install zizmor
+    fi
+}
+
+# Install Linux dependencies
+install_linux_deps() {
+    log_info "Installing Linux dependencies"
+
+    # Update package lists
+    log_info "Updating package lists"
+    sudo apt-get update
+
+    # Configure locales
+    log_info "Configuring locales"
+    sudo apt-get install -y locales
+    echo "en_US.UTF-8 UTF-8" | sudo tee -a /etc/locale.gen >/dev/null
+    sudo locale-gen
+    sudo update-locale LANG=en_US.UTF-8
+
+    # Install essential system packages
+    log_info "Installing essential system packages"
+    essential_packages="sudo curl wget git ca-certificates gnupg lsb-release apt-transport-https"
+    sudo apt-get install -y $essential_packages
+
+    # Install build tools and development libraries
+    log_info "Installing build tools and development libraries"
+    build_packages="build-essential g++ gcc make pkg-config llvm"
+    dev_libraries="libbz2-dev libcairo2-dev libffi-dev liblzma-dev libncurses5-dev libncursesw5-dev libpq-dev libreadline-dev libsqlite3-dev libssl-dev libyaml-dev python3-dev python3-openssl zlib1g-dev tk-dev"
+
+    sudo apt-get install -y $build_packages $dev_libraries
+
+    # Install shells and utilities
+    log_info "Installing shells and utilities"
+    shell_packages="zsh fish elvish zsh-doc"
+    utility_packages="tree unzip vim xz-utils sqlite3 openssl procps manpages manpages-dev bash-completion gzip"
+
+    sudo apt-get install -y $shell_packages $utility_packages
+
+    # Install Python 3.12 if not available from system packages
+    if ! command -v python3.12 >/dev/null 2>&1; then
+        log_info "Installing Python 3.12"
+        sudo apt-get install -y software-properties-common
+        sudo add-apt-repository -y ppa:deadsnakes/ppa
+        sudo apt-get update
+        sudo apt-get install -y python3.12 python3.12-dev python3.12-venv
+    fi
+
+    # Install Go 1.20.5 if not available
+    if ! command -v go >/dev/null 2>&1 || [ "$(go version | cut -d' ' -f3)" != "go1.20.5" ]; then
+        log_info "Installing Go 1.20.5"
+        cd /tmp
+        wget -q https://go.dev/dl/go1.20.5.linux-amd64.tar.gz
+        sudo rm -rf /usr/local/go
+        sudo tar -C /usr/local -xzf go1.20.5.linux-amd64.tar.gz
+        rm go1.20.5.linux-amd64.tar.gz
+
+        # Add Go to PATH
+        if ! echo "$PATH" | grep -q "/usr/local/go/bin"; then
+            echo 'export PATH=$PATH:/usr/local/go/bin' >> "$HOME/.bashrc"
+            export PATH=$PATH:/usr/local/go/bin
+        fi
+    fi
+}
+
+# Run the appropriate platform installer
+run_platform_installer() {
+    log_info "Running platform-specific installer"
+
+    case "$PLATFORM" in
+        macos)
+            installer_script="./bin/zsh-dotfiles-prereq-installer"
+            ;;
+        linux)
+            installer_script="./bin/zsh-dotfiles-prereq-installer-linux"
+            ;;
+    esac
+
+    if [ ! -f "$installer_script" ]; then
+        log_error "Platform installer not found: $installer_script"
+        log_error "Make sure you're running this script from the repository root"
+        exit 1
+    fi
+
+    # Make installer executable
+    chmod +x "$installer_script"
+
+    # Run installer with debug flag
+    log_info "Running $installer_script --debug"
+    "$installer_script" --debug
+
+    # Run installer again for verification (as done in CI)
+    log_info "Running installer again for verification"
+    "$installer_script" --debug
+}
+
+# Main function
+main() {
+    log_info "Starting zsh-dotfiles-prep dependency installation"
+
+    # Check if not running as root
+    check_root
+
+    # Detect platform
+    detect_platform
+
+    # Set environment variables
+    set_default_env_vars
+
+    # Check prerequisites
+    check_prerequisites
+
+    # Install platform-specific dependencies
+    case "$PLATFORM" in
+        macos)
+            install_macos_deps
+            ;;
+        linux)
+            install_linux_deps
+            ;;
+    esac
+
+    # Run the platform installer
+    run_platform_installer
+
+    log_info "Installation completed successfully!"
+    log_info "Your system is now ready for bossjones/zsh-dotfiles"
+    log_info ""
+    log_info "Next steps:"
+    log_info "1. Restart your shell or source your shell configuration"
+    log_info "2. Run: chezmoi init --apply https://github.com/bossjones/zsh-dotfiles.git"
+}
+
+# Run main function
+main "$@"

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -7,8 +7,8 @@ rules:
     config:
       severity: warn
 
-# This section configures how Zizmor handles unpinned action references
-# It defines pinning policies for different action patterns
+  # This section configures how Zizmor handles unpinned action references
+  # It defines pinning policies for different action patterns
   unpinned-uses:
     config:
       policies:
@@ -20,7 +20,7 @@ rules:
         # For all other actions (*), require hash-pin (e.g., @hash) for maximum security
         "*": hash-pin
 
-# This section configures which actions are completely forbidden from being used
+  # This section configures which actions are completely forbidden from being used
   forbidden-uses:
     config:
       deny:
@@ -32,5 +32,5 @@ rules:
     ignore:
       # Ignore template injection warnings for the manifest creation and inspection steps
       # These are safe as the registry variables are controlled by the workflow
-      - tests-e2e.yml  # Create merged manifest step
+      - tests-e2e.yml # Create merged manifest step
       # - ".github/workflows/tests-e2e.yml:350:352"  # Inspect merged image step


### PR DESCRIPTION
- Introduced `install.sh`, a POSIX-compliant installer for setting up dependencies on macOS and Linux, enhancing the ease of environment setup.
- Created `CLAUDE.md` to provide comprehensive guidance on using the repository, including quick start instructions, essential commands, and development workflows.
- Added `.claude/settings.local.json` to manage permissions for the installation scripts, ensuring secure execution.
- Updated the `Makefile` to include a new target `fix` for running pre-commit hooks, improving code quality and consistency.
- These additions aim to streamline the setup process for developers and enhance the overall usability of the zsh-dotfiles-prep repository.