### PR TITLE
fix: add .node-version to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,4 @@ cython_debug/
 .envrc
 *.log
 .ruff_cache/
+.node-version


### PR DESCRIPTION
- Added `.node-version` to the `.gitignore` file to prevent tracking of Node.js version specifications in the project. This change enhances flexibility by allowing developers to manage their Node.js versions without interference from version control.
- This update aligns with previous changes that removed the `.node-version` file, ensuring a consistent approach to Node.js version management across the project.