### PR TITLE
fix: update environment variables and installation instructions in in…

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -9,7 +9,8 @@
       "Bash(docker run:*)",
       "Bash(./install.sh:*)",
       "Bash(make:*)",
-      "Bash(contrib/style.sh:*)"
+      "Bash(contrib/style.sh:*)",
+      "Bash(rg:*)"
     ],
     "deny": []
   }

--- a/install.sh
+++ b/install.sh
@@ -95,6 +95,8 @@ set_default_env_vars() {
   export LANG="${LANG:-en_US.UTF-8}"
   export LANGUAGE="${LANGUAGE:-en_US:en}"
   export LC_ALL="${LC_ALL:-en_US.UTF-8}"
+  export SHELDON_CONFIG_DIR="$HOME/.sheldon"
+  export SHELDON_DATA_DIR="$HOME/.sheldon"
 
   log_debug "Environment variables set"
 }
@@ -493,12 +495,14 @@ main() {
   # Run the platform installer
   run_platform_installer
 
+
+
   log_info "Installation completed successfully!"
   log_info "Your system is now ready for bossjones/zsh-dotfiles"
   log_info ""
   log_info "Next steps:"
   log_info "1. Restart your shell or source your shell configuration"
-  log_info "2. Run: chezmoi init --apply https://github.com/bossjones/zsh-dotfiles.git"
+  log_info "2. Run: chezmoi init -R --debug -v --apply https://github.com/bossjones/zsh-dotfiles.git"
 }
 
 # Run main function


### PR DESCRIPTION
…stall.sh

- Added SHELDON_CONFIG_DIR and SHELDON_DATA_DIR environment variables to support the Sheldon plugin manager.
- Updated the installation instructions to include the `-R --debug -v` flags for the chezmoi command, enhancing clarity for users on the next steps after installation.