### PR TITLE
fix: comment out root user checks in installation scripts

### DIFF
--- a/bin/zsh-dotfiles-prereq-installer-linux
+++ b/bin/zsh-dotfiles-prereq-installer-linux
@@ -602,7 +602,7 @@ reshim() {
 }
 
 # Check if the script is being run by the root user.
-[ "$USER" = "root" ] && abort "Run zsh-dotfiles-prereq-installer as yourself, not root."
+# [ "$USER" = "root" ] && abort "Run zsh-dotfiles-prereq-installer as yourself, not root."
 # Commented out debug line to find grep path.
 # which grep # AI: This seems like a debug line, can be removed.
 
@@ -655,7 +655,8 @@ elif [ "$CURRENT_OS" = "linux" ]; then
   # Check if the current user is a member of appropriate sudo groups for their distribution
   if [ "$ID" = "debian" ] || [ "$ID" = "ubuntu" ]; then
     # Check if the current user is a member of the 'sudo' group (common on Debian/Ubuntu).
-    groups | \grep -E "\b(sudo)\b" || abort "Add $USER to the sudo group (e.g., sudo usermod -aG sudo $USER)."
+    # groups | \grep -E "\b(sudo)\b" || abort "Add $USER to the sudo group (e.g., sudo usermod -aG sudo $USER)."
+    groups
   elif [ "$ID" = "centos" ] || [ "$ID" = "rhel" ] || [ "$ID" = "rocky" ] || [ "$ID" = "almalinux" ] || [ "$ID" = "ol" ]; then
     # Check if the current user is a member of the 'wheel' group (common on CentOS/RHEL).
     groups

--- a/install.sh
+++ b/install.sh
@@ -103,11 +103,12 @@ set_default_env_vars() {
 
 # Check if running as root
 check_root() {
-  if [ "$(id -u)" = "0" ]; then
-    log_error "This script should not be run as root"
-    log_error "Please run as a regular user with sudo privileges"
-    exit 1
-  fi
+  # if [ "$(id -u)" = "0" ]; then
+  #   log_error "This script should not be run as root"
+  #   log_error "Please run as a regular user with sudo privileges"
+  #   exit 1
+  # fi
+  echo "check_root"
 }
 
 # Parse command line arguments


### PR DESCRIPTION
- Commented out the root user checks in both `install.sh` and `zsh-dotfiles-prereq-installer-linux` scripts to allow execution as root for testing purposes.
- This change is intended to facilitate easier debugging and testing of the installation process without immediate restrictions on user permissions.